### PR TITLE
Fix sample code in README.md to avoid attaching duplicate load events

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ if (lazyImage) {
   const callback = (entries, observer) => {
     Array.from(entries).forEach((entry, index) => {
       // If any of the images have come in to view, activate them sequentially
-      if (entry.isIntersecting) {
+      if (entry.isIntersecting && !entry.target.dataset.activating) {
+        entry.target.dataset.activating = true
         window.setTimeout(() => {
           new LazyImage({ el: entry.target })
           observer.unobserve(entry.target)


### PR DESCRIPTION
This could happen when a lazy image element is brought into view, moved out of view, then quickly moved back into view again. This only happens sporadically and only with weird (but not deliberate) scrolling behaviour. :) But when it does happen, it causes an exception as it attempts to remove the placeholder image twice (i.e. `parentElement.removeChild` being called when `parentElement` doesn't exist on a detached DOM node).